### PR TITLE
added option to format typescript automatically on save #38

### DIFF
--- a/src/com.axmor.eclipse.typescript.core/src/com/axmor/eclipse/typescript/core/TypeScriptEditorSettings.java
+++ b/src/com.axmor.eclipse.typescript.core/src/com/axmor/eclipse/typescript/core/TypeScriptEditorSettings.java
@@ -47,6 +47,8 @@ public final class TypeScriptEditorSettings {
     private boolean insertCloseBrackets = true;
     /** InsertSemicolons. */
     private boolean insertSemicolons = true;
+    /** AutoFormatOnSave. */
+    private boolean autoFormatOnSave = true;
 
     /**
      * @return the indentSize
@@ -243,6 +245,14 @@ public final class TypeScriptEditorSettings {
     public void setInsertCloseBrackets(boolean insertCloseBrackets) {
         this.insertCloseBrackets = insertCloseBrackets;
     }
+    
+    public boolean isAutoFormatOnSave() {
+        return autoFormatOnSave;
+    }
+    
+    public void setAutoFormatOnSave(boolean autoFormatOnSave) {
+        this.autoFormatOnSave = autoFormatOnSave;        
+    }    
 
     /**
      * Loads settings from preferences.
@@ -263,6 +273,9 @@ public final class TypeScriptEditorSettings {
         }
         if (store.contains("convertTabs")) {
             settings.setConvertTabsToSpaces(store.getBoolean("convertTabs"));
+        }
+        if (store.contains("autoFormatOnSave")) {
+            settings.setAutoFormatOnSave(store.getBoolean("autoFormatOnSave"));
         }
         if (store.contains("insertSpaceComma")) {
             settings.setInsertSpaceAfterCommaDelimiter(store.getBoolean("insertSpaceComma"));
@@ -306,6 +319,7 @@ public final class TypeScriptEditorSettings {
         store.setValue("tabSize", getTabSize());
         store.setValue("newLineChar", getNewLineCharacter());
         store.setValue("convertTabs", isConvertTabsToSpaces());
+        store.setValue("autoFormatOnSave", isAutoFormatOnSave());
         store.setValue("insertSpaceComma", isInsertSpaceAfterCommaDelimiter());
         store.setValue("insertSpaceSemicolon", isInsertSpaceAfterSemicolon());
         store.setValue("insertSpaceBinary", isInsertSpaceBinaryOperators());
@@ -327,6 +341,7 @@ public final class TypeScriptEditorSettings {
         store.setToDefault("tabSize");
         store.setToDefault("newLineChar");
         store.setToDefault("convertTabs");
+        store.setToDefault("autoFormatOnSave");
         store.setToDefault("insertSpaceComma");
         store.setToDefault("insertSpaceSemicolon");
         store.setToDefault("insertSpaceBinary");

--- a/src/com.axmor.eclipse.typescript.core/src/com/axmor/eclipse/typescript/core/TypeScriptSettingsInitializer.java
+++ b/src/com.axmor.eclipse.typescript.core/src/com/axmor/eclipse/typescript/core/TypeScriptSettingsInitializer.java
@@ -27,6 +27,7 @@ public class TypeScriptSettingsInitializer extends AbstractPreferenceInitializer
         store.setDefault("tabSize", 4);
         store.setDefault("newLineChar", "\r\n");
         store.setDefault("convertTabs", true);
+        store.setDefault("autoFormatOnSave", true);
         store.setDefault("insertSpaceComma", true);
         store.setDefault("insertSpaceSemicolon", true);
         store.setDefault("insertSpaceBinary", true);
@@ -36,6 +37,7 @@ public class TypeScriptSettingsInitializer extends AbstractPreferenceInitializer
         store.setDefault("placeBraceFunctions", false);
         store.setDefault("placeBraceBlocks", false);
         store.setDefault("insertCloseBrackets", true);
+        store.setDefault("insertSemicolons", true);
     }
 
 }

--- a/src/com.axmor.eclipse.typescript.core/src/com/axmor/eclipse/typescript/core/ui/TypescriptEditorPreferencePage.java
+++ b/src/com.axmor.eclipse.typescript.core/src/com/axmor/eclipse/typescript/core/ui/TypescriptEditorPreferencePage.java
@@ -55,6 +55,8 @@ public class TypescriptEditorPreferencePage extends PreferencePage implements IW
     private Button insertCloseBrackets;
     /** insertSemicolons field. */
     private Button insertSemicolons;
+    /** autoFormatOnSave field. */
+    private Button autoFormatOnSave;
 
     @Override
     public void init(IWorkbench workbench) {
@@ -79,6 +81,8 @@ public class TypescriptEditorPreferencePage extends PreferencePage implements IW
         convertTabs = SWTFactory.createCheckButton(editor, "Convert tabs to spaces", null, true, 2);
 
         Group formatting = SWTFactory.createGroup(composite, "Formatting rules", 1, 1, GridData.FILL_HORIZONTAL);
+        autoFormatOnSave = SWTFactory.createCheckButton(formatting, "Format code automatically on save", 
+                null, true, 1);
         insertSpaceComma = SWTFactory
                 .createCheckButton(formatting, "Insert space after comma delimiter", null, true, 1);
         insertSpaceSemicolon = SWTFactory.createCheckButton(formatting,
@@ -114,6 +118,7 @@ public class TypescriptEditorPreferencePage extends PreferencePage implements IW
         tabSize.setText(String.valueOf(settings.getTabSize()));
 
         convertTabs.setSelection(settings.isConvertTabsToSpaces());
+        autoFormatOnSave.setSelection(settings.isAutoFormatOnSave());
         insertSpaceComma.setSelection(settings.isInsertSpaceAfterCommaDelimiter());
         insertSpaceSemicolon.setSelection(settings.isInsertSpaceAfterSemicolon());
         insertSpaceBinary.setSelection(settings.isInsertSpaceBinaryOperators());
@@ -134,6 +139,7 @@ public class TypescriptEditorPreferencePage extends PreferencePage implements IW
         settings.setTabSize(Integer.parseInt(tabSize.getText()));
 
         settings.setConvertTabsToSpaces(convertTabs.getSelection());
+        settings.setAutoFormatOnSave(autoFormatOnSave.getSelection());
         settings.setInsertSpaceAfterCommaDelimiter(insertSpaceComma.getSelection());
         settings.setInsertSpaceAfterSemicolon(insertSpaceSemicolon.getSelection());
         settings.setInsertSpaceBinaryOperators(insertSpaceBinary.getSelection());

--- a/src/com.axmor.eclipse.typescript.editor/src/com/axmor/eclipse/typescript/editor/handlers/FormatCodeHandler.java
+++ b/src/com.axmor.eclipse.typescript.editor/src/com/axmor/eclipse/typescript/editor/handlers/FormatCodeHandler.java
@@ -50,13 +50,19 @@ public class FormatCodeHandler extends AbstractHandler {
             return null;
         }
         IDocument document = editor.getDocumentProvider().getDocument(HandlerUtil.getActiveEditorInput(event));
-        IDocumentExtension4 ex4 = (IDocumentExtension4) document; 
+        formatCode(editor, document);
+        return null;
+    }
+
+    public static void formatCode(TypeScriptEditor editor, IDocument document) {
+        IDocumentExtension4 ex4 = (IDocumentExtension4) document;
         ITextSelection selection = (ITextSelection) editor.getSelectionProvider().getSelection();
         int start = selection.getOffset();
         int end = start + selection.getLength();
         IFile file = ((FileEditorInput) editor.getEditorInput()).getFile();
-        //if selection length equals 0 we will format the document till the end
+        // if selection length equals 0 we will format the document till the end
         if (selection.getLength() == 0) {
+            start = 0;
             end = document.getLength();
         }
         editor.getApi().updateFileContent(file, document.get());
@@ -67,7 +73,7 @@ public class FormatCodeHandler extends AbstractHandler {
             for (int i = 0; i < formatDetails.length(); i++) {
                 JSONObject object = formatDetails.getJSONObject(i);
                 Position position = TypeScriptEditorUtils.getPosition(object);
-                if (position.offset == end)//Ignore space that added by ets_host.js
+                if (position.offset == end)// Ignore space that added by ets_host.js
                     continue;
                 if ((object == null) || (position.offset < start) || (position.offset > end)) {
                     break;
@@ -93,7 +99,5 @@ public class FormatCodeHandler extends AbstractHandler {
         } catch (JSONException | MalformedTreeException | BadLocationException e) {
             throw Throwables.propagate(e);
         }
-        return null;
     }
-
 }


### PR DESCRIPTION
Added a new option "Format code automatically on save" under Windows / Preferences / TypeScript / Editor into a Formatting rules block.
