### PR TITLE
Use dependencies range instead of fix dependencies version between

### DIFF
--- a/src/com.axmor.eclipse.typescript.feature/feature.xml
+++ b/src/com.axmor.eclipse.typescript.feature/feature.xml
@@ -18,17 +18,11 @@
       %license
    </license>
 
-   <includes
-         id="org.chromium.sdk"
-         version="0.0.0"/>
-
-   <includes
-         id="org.chromium.sdk.wipbackends"
-         version="0.0.0"/>
-
-   <includes
-         id="org.chromium.debug"
-         version="0.0.0"/>
+   <requires>
+      <import feature="org.chromium.debug" version="0.3.8" match="compatible"/>
+      <import feature="org.chromium.sdk" version="0.3.8" match="compatible"/>
+      <import feature="org.chromium.sdk.wipbackends" version="0.1.10" match="compatible"/>
+   </requires>
 
    <plugin
          id="com.axmor.eclipse.typescript"

--- a/src/com.axmor.eclipse.typescript/.classpath
+++ b/src/com.axmor.eclipse.typescript/.classpath
@@ -2,6 +2,5 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -115,6 +115,14 @@
          </execution>
        </executions>
       </plugin>
+      <plugin>
+         <groupId>org.eclipse.tycho</groupId>
+         <artifactId>tycho-p2-repository-plugin</artifactId>
+         <version>${tycho.version}</version>
+         <configuration>
+            <includeAllDependencies>true</includeAllDependencies>
+         </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
This would allow to install Typecs with Nodeclipse/Enide.

Using include feature is not really a good thing because then features version are fixed, and it is not possible to use version range.

This update would allow to define a version range for dependences and tycho built is update to built a self contained update site, so if users already have chrome dev tools installed (with nodeclipse/enide), typecs can be installed. If the user does not have chrome dev tools it is available from typecs p2 repository as before
