### PR TITLE
Modified 'isTargetRelativePathBasedOnSource' algorithm to use TypeScr…

### DIFF
--- a/src/com.axmor.eclipse.typescript.core/lib/typescript-bridge/js/service.js
+++ b/src/com.axmor.eclipse.typescript.core/lib/typescript-bridge/js/service.js
@@ -213,6 +213,7 @@ var TSService = (function () {
             module: s.moduleGenTarget,
             out: s.outFileOption === "" ? "" : basedir + "/" + s.outFileOption,
             outDir: s.outDirOption === "" ? "" : basedir + "/" + s.outDirOption,
+            rootDir: s.rootDir,
             sourceMap: s.mapSourceFiles,
             mapRoot: s.mapRoot,
             sourceRoot: s.sourceRoot,

--- a/src/com.axmor.eclipse.typescript.core/lib/typescript-bridge/src/service.ts
+++ b/src/com.axmor.eclipse.typescript.core/lib/typescript-bridge/src/service.ts
@@ -247,6 +247,7 @@ export class TSService {
             module: s.moduleGenTarget,
             out: s.outFileOption === "" ? "" : basedir + "/" + s.outFileOption,
             outDir: s.outDirOption === "" ? "" : basedir + "/" + s.outDirOption,
+            rootDir: s.rootDir,
             sourceMap: s.mapSourceFiles,
             mapRoot: s.mapRoot,
             sourceRoot: s.sourceRoot,

--- a/src/com.axmor.eclipse.typescript.core/src/com/axmor/eclipse/typescript/core/internal/TypeScriptAPIImpl.java
+++ b/src/com.axmor.eclipse.typescript.core/src/com/axmor/eclipse/typescript/core/internal/TypeScriptAPIImpl.java
@@ -13,7 +13,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.core.filesystem.URIUtil;
-import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -232,12 +231,9 @@ public class TypeScriptAPIImpl implements TypeScriptAPI {
                 params.put("outFileOption", "");
                 String outDirOption = settingsTarget;
                 if (settings.isTargetRelativePathBasedOnSource()) {
-                    IContainer inputFileDir = file.getParent();
-                    IPath sourceDir = Strings.isNullOrEmpty(settings.getSource()) ? file.getProject().getFullPath()
-                            : file.getProject().getFolder(settings.getSource()).getFullPath();
-                    IPath relativePath = inputFileDir.getFullPath().makeRelativeTo(sourceDir);
-                    outDirOption = Strings.isNullOrEmpty(outDirOption) ? relativePath.toString() : outDirOption + "/"
-                            + relativePath.toString();
+                	String folder = Strings.isNullOrEmpty(settings.getSource()) ? "./" : settings.getSource();
+                	final String rootDir = file.getProject().getFolder(folder).getLocation().toFile().getAbsolutePath().replace('\\', '/');
+                   	params.put("rootDir", rootDir);
                 }
 				if (Strings.isNullOrEmpty(outDirOption)) {
 					outDirOption = file.getParent().getProjectRelativePath().toString();


### PR DESCRIPTION
…ipt 1.5 feature 'rootDir'

We experienced a broken output. We use "relative paths" and at some circumstances (it seems at random, but reproduce-able) the output directories were mixed up. After a little bit of google-ing I found this bug-report: https://github.com/Microsoft/TypeScript/issues/812. The issue was solved by this pull-request: https://github.com/Microsoft/TypeScript/pull/2772. It was solved by adding a new parameter "rootDir" which can be used for building output-paths as relative paths based on this root directory under which the files to be compiled are placed. As this matches the typecs-plugin's feature 'Set relative path from target directory to output file based on relative path from source directory to input file' I re-factored this feature to use the new "rootDir" parameter instead of calculating the relative path by the plugin. This fixed our broken output.
